### PR TITLE
Update to new zxing-cpp version, fix UB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tempdir = "0.3"
 [dependencies]
 image = "0.23"
 num = "0.2"
+bitflags = "1.0"
 
 [features]
 parallel = ["cc/parallel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,14 @@ include = [
 
 [build-dependencies]
 glob = "0.3.0"
-cc = "1.0.0"
+cc = "1.0"
 
 [dev-dependencies]
 tempdir = "0.3"
 
 [dependencies]
-image = "0.21"
+image = "0.23"
 num = "0.2"
 
 [features]
 parallel = ["cc/parallel"]
-
-[patch.crates-io]
-cc = { path = '/Users/yuta/repos/ghq/github.com/alexcrichton/cc-rs' }
-

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,20 @@
-use std::path::Path;
+use cc;
 use glob::glob;
 use std::env;
+use std::path::Path;
 use std::vec;
-use cc;
 
 fn main() {
     let c_api_src_dir = Path::new("c_api/src");
     let c_api_sources: Vec<_> = glob(c_api_src_dir.join("*.cpp").to_str().unwrap())
         .unwrap()
-        .map(|x| { x.unwrap() })
-        .collect()
-    ;
+        .map(|x| x.unwrap())
+        .collect();
     let core_src_dir = Path::new("submodules/zxing-cpp/core/src");
     let core_sources: Vec<_> = glob(core_src_dir.join("**/*.cpp").to_str().unwrap())
         .unwrap()
-        .map(|x| { x.unwrap() })
-        .collect()
-    ;
+        .map(|x| x.unwrap())
+        .collect();
 
     cc::Build::new()
         .cpp(true)
@@ -24,9 +22,7 @@ fn main() {
         .flag("-Wno-missing-braces")
         .include(core_src_dir)
         .files(core_sources)
-        .skip_when_compiled(true)
-        .compile("zxing_core")
-    ;
+        .compile("zxing_core");
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
@@ -35,6 +31,5 @@ fn main() {
         .include(c_api_src_dir)
         .include(core_src_dir)
         .files(c_api_sources)
-        .compile("zxing_c_api")
-    ;
+        .compile("zxing_c_api");
 }

--- a/build.rs
+++ b/build.rs
@@ -18,14 +18,14 @@ fn main() {
 
     cc::Build::new()
         .cpp(true)
-        .flag("-std=c++11")
+        .flag("-std=c++14")
         .flag("-Wno-missing-braces")
         .include(core_src_dir)
         .files(core_sources)
         .compile("zxing_core");
     cc::Build::new()
         .cpp(true)
-        .flag("-std=c++11")
+        .flag("-std=c++14")
         .flag("-v")
         .flag("-g")
         .include(c_api_src_dir)

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,6 @@
 use cc;
 use glob::glob;
-use std::env;
 use std::path::Path;
-use std::vec;
 
 fn main() {
     let c_api_src_dir = Path::new("c_api/src");

--- a/c_api/src/reader.cpp
+++ b/c_api/src/reader.cpp
@@ -46,6 +46,15 @@ zxing_read_qrcode(ZXING_RESULT **result, const uint8_t *buffer, int width, int h
     std::memcpy((*result)->bytes, s.data(), sizeof(char) * s.size());
     (*result)->bytes_size = sizeof(char) * s.size();
 
+    ZXing::Quadrilateral<ZXing::PointT<int>> pos = reader_result.position();
+    (*result)->corners[0] = pos.topLeft().x;
+    (*result)->corners[1] = pos.topLeft().y;
+    (*result)->corners[2] = pos.topRight().x;
+    (*result)->corners[3] = pos.topRight().y;
+    (*result)->corners[4] = pos.bottomRight().x;
+    (*result)->corners[5] = pos.bottomRight().y;
+    (*result)->corners[6] = pos.bottomLeft().x;
+    (*result)->corners[7] = pos.bottomLeft().y;
     return 0;
 }
 

--- a/c_api/src/reader.cpp
+++ b/c_api/src/reader.cpp
@@ -10,8 +10,8 @@
 #include "GenericLuminanceSource.h"
 #include "HybridBinarizer.h"
 #include "TextUtfEncoding.h"
+#include <cstring>
 #include <iostream>
-
 
 using Binarizer = ZXing::HybridBinarizer;
 

--- a/c_api/src/reader.cpp
+++ b/c_api/src/reader.cpp
@@ -21,7 +21,7 @@ zxing_read_qrcode(ZXING_RESULT **result, const uint8_t *buffer, int width, int h
                   int index_g, int index_b)
 {
     ZXing::DecodeHints hints;
-    hints.setShouldTryHarder(true);
+    hints.setTryHarder(true);
     ZXing::MultiFormatReader reader(hints);
 
     ZXing::GenericLuminanceSource source((int)width, (int)height, buffer, row_bytes, pixel_bytes, index_r, index_g, index_b);

--- a/c_api/src/reader.h
+++ b/c_api/src/reader.h
@@ -13,6 +13,7 @@ typedef struct ZxingQrResult {
     int format;
     uint8_t* bytes;
     int bytes_size;
+    int corners[8];
 } ZXING_RESULT;
 
 


### PR DESCRIPTION
Hi, I hope you are keeping well :)

 - Updated zxing-cpp to `v1.1.1`, and updated the `Formats` type to be a bitfield as thats what zxing seem to use now. This also involved bumping the c++ version to c++14, which should be okay as all compilers should carry that now
 - Fixed some of the compiler warnings
 - Run `cargo fmt`
 - Updated to newer dependencies in `cc` and `image`.
 - Confirmed that all the tests pass.
 
 I hope this is is good to merge. Please let me know if theres anything else I can do to help.
 
Thanks,
Tom